### PR TITLE
PVS attempt 3 and knuckles

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -432,13 +432,9 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 		*/
 
 		// Principal variation search (based on Stoat shogi engine by Ciekce)
-		score = -negamax_alphabeta(pos, table, info, -beta, -alpha, reduced_depth, &candidate_PV, true, true);
-		if (PV_node) {
-
-		}
+		// score = -negamax_alphabeta(pos, table, info, -beta, -alpha, reduced_depth, &candidate_PV, true, true);
 
 		// If we are in a non-PV node, OR we are in a PV-node examining moves after the 1st legal move
-		/*
 		if (!PV_node || legal > 1) {
 			// Perform zero-window search (ZWS) on non-PV nodes
 			score = -negamax_alphabeta(pos, table, info, -alpha - 1, -alpha, reduced_depth, &candidate_PV, true, false);
@@ -447,8 +443,7 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 		if (PV_node && (legal == 1 || score > alpha)) {
 			score = -negamax_alphabeta(pos, table, info, -beta, -alpha, reduced_depth, &candidate_PV, true, true);
 		}
-		*/
-
+		
 		take_move(pos);
 
 		if (info->stopped) {


### PR DESCRIPTION
Bench: 1719961

```Elo   | -5.38 +- 3.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -3.11 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 22236 W: 8416 L: 8760 D: 5060
Penta | [1372, 1952, 4728, 1780, 1286]
https://chess.n9x.co/test/3448/
```
Doesn't quite pass nonreg, but nonetheless important feature for future enhancements