### PR TITLE
Lmr twotables

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -633,9 +633,9 @@ void init_searchinfo(SearchInfo* info) {
 void init_LMR_table() {
 	for (int depth = 3; depth < MAX_DEPTH; ++depth) {
 		for (int move_num = 4; move_num < 280; ++move_num) {
-			// [0]: Noisy, [1]: Quiet (Values yoinked from Weiss)
+			// [0]: Noisy, [1]: Quiet
 			LMR_reduction_table[depth][move_num][0] = int(0.25 + log(depth) * log(move_num) / 3.25);
-			LMR_reduction_table[depth][move_num][1] = int(0.50 + log(depth) * log(move_num) / 2.75);
+			LMR_reduction_table[depth][move_num][1] = int(0.50 + log(depth) * log(move_num) / 3.00);
 		}
 	}
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -634,7 +634,7 @@ void init_LMR_table() {
 	for (int depth = 3; depth < MAX_DEPTH; ++depth) {
 		for (int move_num = 4; move_num < 280; ++move_num) {
 			// [0]: Quiet, [1]: Noisy (Values yoinked from Weiss)
-			LMR_reduction_table[depth][move_num][0] = int(1.35 + log(depth) * log(move_num) / 2.75);
+			LMR_reduction_table[depth][move_num][0] = int(1.00 + log(depth) * log(move_num) / 3.00);
 			LMR_reduction_table[depth][move_num][1] = int(0.20 + log(depth) * log(move_num) / 3.35);
 		}
 	}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -635,7 +635,7 @@ void init_LMR_table() {
 		for (int move_num = 4; move_num < 280; ++move_num) {
 			// [0]: Noisy, [1]: Quiet (Values yoinked from Weiss)
 			LMR_reduction_table[depth][move_num][0] = int(0.25 + log(depth) * log(move_num) / 3.25);
-			LMR_reduction_table[depth][move_num][1] = int(0.50 + log(depth) * log(move_num) / 3.00);
+			LMR_reduction_table[depth][move_num][1] = int(0.50 + log(depth) * log(move_num) / 2.75);
 		}
 	}
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -421,7 +421,7 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 		if (depth >= 3 && move_num >= 4 && !is_mate) {
 			
 			// Base reduction based on depth, move number and whether the move is quiet or not
-			int r = std::max(0, LMR_reduction_table[depth][move_num][!is_quiet]); // Depth to be reduced
+			int r = std::max(0, LMR_reduction_table[depth][move_num][is_quiet]); // Depth to be reduced
 			r += !PV_node; // Reduce more if not PV-node
 			reduced_depth = std::max(reduced_depth - r - 1, 1);
 
@@ -633,9 +633,9 @@ void init_searchinfo(SearchInfo* info) {
 void init_LMR_table() {
 	for (int depth = 3; depth < MAX_DEPTH; ++depth) {
 		for (int move_num = 4; move_num < 280; ++move_num) {
-			// [0]: Quiet, [1]: Noisy (Values yoinked from Weiss)
-			LMR_reduction_table[depth][move_num][0] = int(1.00 + log(depth) * log(move_num) / 3.00);
-			LMR_reduction_table[depth][move_num][1] = int(0.20 + log(depth) * log(move_num) / 3.35);
+			// [0]: Noisy, [1]: Quiet (Values yoinked from Weiss)
+			LMR_reduction_table[depth][move_num][0] = int(0.25 + log(depth) * log(move_num) / 3.25);
+			LMR_reduction_table[depth][move_num][1] = int(0.50 + log(depth) * log(move_num) / 3.00);
 		}
 	}
 }

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -30,7 +30,7 @@ typedef struct {
 	float fhf; // legal moves
 } SearchInfo;
 
-extern int LMR_reduction_table[MAX_DEPTH][280]; // [ply][move_num]
+extern int LMR_reduction_table[MAX_DEPTH][280][2]; // [ply][move_num][is_noisy]
 
 // Functions
 void search_position(Board* pos, HashTable* table, SearchInfo* info);

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -30,7 +30,7 @@ typedef struct {
 	float fhf; // legal moves
 } SearchInfo;
 
-extern int LMR_reduction_table[MAX_DEPTH][280][2]; // [ply][move_num][is_noisy]
+extern int LMR_reduction_table[MAX_DEPTH][280][2]; // [ply][move_num][is_quiet]
 
 // Functions
 void search_position(Board* pos, HashTable* table, SearchInfo* info);


### PR DESCRIPTION
Inconclusive after ~14k games. I will test this again in the future.
```
Elo   | 2.60 +- 4.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.71 (-2.94, 2.94) [0.00, 10.00]
Games | N: 14292 W: 5102 L: 4995 D: 4195
Penta | [593, 1360, 3175, 1383, 635]
https://chess.n9x.co/test/3505/
```
Hypothetical result if non-reg was done:
```
Elo: 2.60 (-4.79 / +4.79) [-2.19 to 7.39]
nElo: 3.09 (-5.70 / +5.70) [-2.60 to 8.79]
BayesElo: 2.85 (-5.24 / +5.24) [-2.39 to 8.09]
LLR: 9.5769
Calculated via https://elocalculator.netlify.app/
```
Therefore I am merging with these preliminary values regardless.
Bench: 1558659