### PR TITLE
Probe and save TT in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -189,8 +189,9 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	init_PVLine(&candidate_PV);
 
 	int stand_pat = evaluate_pos(pos);
+	int old_alpha = alpha;
 	int best_score = stand_pat;
-	// int best_move = NO_MOVE;
+	int best_move = NO_MOVE;
 	int score = -INF_BOUND;
 
 	if (stand_pat >= beta) {
@@ -246,7 +247,7 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 
 		if (score > best_score) {
 			best_score = score;
-			// best_move = curr_move;
+			best_move = curr_move;
 
 			if (score > alpha) {
 				alpha = score;
@@ -266,6 +267,19 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 			}
 		}
 	}
+
+	// Store move and score to TT
+	uint8_t hash_flag = HFNONE;
+	if (best_score >= beta) {
+		hash_flag = HFBETA;
+	}
+	else if (best_score > old_alpha) {
+		hash_flag = HFEXACT;
+	}
+	else {
+		hash_flag = HFALPHA;
+	}
+	store_hash_entry(pos, table, best_move, best_score, hash_flag, 0);
 
 	return best_score;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -204,13 +204,11 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	// Transposition table cutoffs
 	// Probe before considering cutoff if it is not root
 	int hash_move = NO_MOVE;
-	/*
 	int hash_score = -INF_BOUND;
 	if (probe_hash_entry(pos, table, hash_move, hash_score, alpha, beta, 0)) {
 		table->cut++;
 		return hash_score;
 	}
-	*/
 	
 	/*
 		Delta pruning (dead lost scenario)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,12 +188,13 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	PVLine candidate_PV;
 	init_PVLine(&candidate_PV);
 
-	int stand_pat = evaluate_pos(pos);
+	// Use hash score as stand pat if no cutoffs
+	int stand_pat = /*(hash_score != -INF_BOUND) ? hash_score :*/ evaluate_pos(pos);
 	int old_alpha = alpha;
+	int score = -INF_BOUND;
 	int best_score = stand_pat;
 	int best_move = NO_MOVE;
-	int score = -INF_BOUND;
-
+	
 	if (stand_pat >= beta) {
 		return beta;
 	}
@@ -201,6 +202,16 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	if (alpha >= beta) {
 		return stand_pat;
 	}
+	
+	/*
+	if (stand_pat >= alpha) {
+		alpha = stand_pat;
+	}
+
+	if (alpha >= beta) {
+		return stand_pat;
+	}
+	*/
 
 	// Transposition table cutoffs
 	// Probe before considering cutoff if it is not root
@@ -210,7 +221,7 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 		table->cut++;
 		return hash_score;
 	}
-	
+
 	/*
 		Delta pruning (dead lost scenario)
 	*/


### PR DESCRIPTION
```
Elo   | 27.73 +- 11.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2172 W: 834 L: 661 D: 677
Penta | [87, 186, 409, 275, 129]
https://chess.n9x.co/test/3507/
```
Though while working on this, I discovered a bug in qsearch code which I'll handle in another branch.
Bench: 1375758