### PR TITLE
Potential QS fix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -195,6 +195,7 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	int best_score = stand_pat;
 	int best_move = NO_MOVE;
 	
+	/*
 	if (stand_pat >= beta) {
 		return beta;
 	}
@@ -202,8 +203,8 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	if (alpha >= beta) {
 		return stand_pat;
 	}
+	*/
 	
-	/*
 	if (stand_pat >= alpha) {
 		alpha = stand_pat;
 	}
@@ -211,7 +212,6 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	if (alpha >= beta) {
 		return stand_pat;
 	}
-	*/
 
 	// Transposition table cutoffs
 	// Probe before considering cutoff if it is not root


### PR DESCRIPTION
```
Elo   | 11.53 +- 7.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.37 (-2.94, 2.94) [0.00, 5.00] (stopped early)
Games | N: 4674 W: 1701 L: 1546 D: 1427
Penta | [207, 464, 899, 501, 266]
https://chess.n9x.co/test/3508/
```
Nonreg:
```
Elo: 11.53 (-8.30 / +8.31) [3.23 to 19.84]
nElo: 13.83 (-9.96 / +9.96) [3.87 to 23.79]
BayesElo: 12.71 (-9.15 / +9.17) [3.56 to 21.88]
Draw Ratio: 0.31
LLR: 3.1553
```
Bench: 1242176