### PR TITLE
Quiethist: Quadratic depth bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -507,7 +507,7 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 
 				// Store the move that beats alpha if it's quiet
 				if (!is_capture) {
-					pos->history_moves[pos->pieces[get_move_source(best_move)]][get_move_target(best_move)] += depth;
+					pos->history_moves[get_move_piece(best_move)][get_move_target(best_move)] += depth * depth;
 				}
 			}
 		}


### PR DESCRIPTION
As recommended by arand
```
Elo   | 2.26 +- 4.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 13228 W: 4610 L: 4524 D: 4094
Penta | [650, 1378, 2487, 1434, 665]
https://chess.n9x.co/test/3556/
```
Bench: 1737260