### PR TITLE
TM: Trying phase-based soft TM

### DIFF
--- a/src/UciHandler.cpp
+++ b/src/UciHandler.cpp
@@ -103,21 +103,16 @@ void UciHandler::parse_go(Board* pos, HashTable* table, SearchInfo* info, const 
         info->hard_stop_time = info->start_time + buffered_time;
 
         // Get soft time limit
+        /*
         buffered_time = std::max((time + inc/2) / 30 - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER / 2);
         // std::cout << "Soft limit: " << buffered_time << "ms\n";
         info->soft_stop_time = info->start_time + buffered_time;
-
-        /*
-        // Get hard time limit
-        int buffered_time = time + inc - std::min(time/2 + inc/2, MIN_NETWORK_BUFFER);
-        double time_allocated = allocate_time(pos, buffered_time);
-        info->hard_stop_time = uint64_t(info->start_time + time_allocated);
+        */
 
         // Get soft time limit
-        buffered_time = time/20 + inc/2 - std::min(time/40 + inc/4, MIN_NETWORK_BUFFER);
+        buffered_time = std::min(allocate_time(pos, time + inc/2 - MIN_NETWORK_BUFFER), MIN_NETWORK_BUFFER);
         //     Prevent soft limit from exceeding hard limit
         info->soft_stop_time = std::min(info->start_time + buffered_time, info->hard_stop_time - MIN_NETWORK_BUFFER / 3);
-        */
 
         // std::cout << "Current time: " << get_time_ms() 
         //    << " | Hard limit: " << info->hard_stop_time << " (" << info->hard_stop_time - get_time_ms() << ") "


### PR DESCRIPTION
Non-reg test:
```
Elo   | 24.56 +- 11.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2182 W: 865 L: 711 D: 606
Penta | [94, 197, 407, 247, 146]
```
https://kelseyde.pythonanywhere.com/test/1246/

Hypothetical gainer test using [this calculator](https://elocalculator.netlify.app/):
```
Points: 1168/2182 (53.53%)
Elo: 24.56 (-12.38 / +12.44) [12.18 to 37.01]
LOS: 100.00%
LLR: 2.3769
```

Using custom phase-based (ply-based) time management for soft time limit
Bench: 1449775