### PR TITLE
Eval/stacked pawns

### DIFF
--- a/src/eval/evaluate.cpp
+++ b/src/eval/evaluate.cpp
@@ -230,7 +230,7 @@ static inline int evaluate_pawns(const Board* pos, uint8_t pce, int phase) {
 		// Stacked pawn penalties
 		uint8_t stacked_count = count_bits(pos->bitboards[pce] & file_masks[file]);
 		if (stacked_count > 1) {
-			score -= stacked_pawn * (stacked_count - 1) / stacked_count; // Scales with the number of pawns stacked
+			score -= stacked_pawn * (stacked_count - 1); // Scales with the number of pawns stacked
 		}
 
 		// Connected passer bonuses

--- a/src/eval/evaluate.hpp
+++ b/src/eval/evaluate.hpp
@@ -19,7 +19,7 @@ const int passer_bonus[8] = { 0, 5, 10, 20, 35, 60, 100, 200 };
 const uint8_t connected_passers = 50;
 const uint8_t isolated_pawn = 10;
 const uint8_t isolated_centre_pawn = 10; // Additional penalty
-const uint8_t stacked_pawn = 10; // multipled by n-1, where n is no. of stacked pawns
+const uint8_t stacked_pawn = 5; // multipled by n-1, where n is no. of stacked pawns
 const uint8_t backwards_pawn = 15;
 
 const uint8_t bishop_pair = 20;


### PR DESCRIPTION
```
Elo   | 0.83 +- 3.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18046 W: 6375 L: 6332 D: 5339
Penta | [734, 1727, 4069, 1748, 745]
```
https://kelseyde.pythonanywhere.com/test/1345/

Nonreg bounds (via [this tool](https://elocalculator.netlify.app/):
Points: 9044.5/18046 (50.12%)
Elo: 0.83 (-4.25 / +4.25) [-3.43 to 5.08]
LOS: 64.85%
LLR: 2.6058

Bench: 1386569