### PR TITLE
Search: Dont save exact in QS

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -188,7 +188,6 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	init_PVLine(&candidate_PV);
 
 	int stand_pat = evaluate_pos(pos);
-	int old_alpha = alpha;
 	int score = -INF_BOUND;
 	int best_score = stand_pat;
 	int best_move = NO_MOVE;
@@ -273,9 +272,6 @@ static inline int quiescence(Board* pos, HashTable* table, SearchInfo* info, int
 	uint8_t hash_flag = HFNONE;
 	if (best_score >= beta) {
 		hash_flag = HFBETA;
-	}
-	else if (best_score > old_alpha) {
-		hash_flag = HFEXACT;
 	}
 	else {
 		hash_flag = HFALPHA;


### PR DESCRIPTION
```
Elo   | 1.69 +- 4.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 15224 W: 5252 L: 5178 D: 4794
Penta | [652, 1572, 3122, 1582, 684]
```
https://kelseyde.pythonanywhere.com/test/1425/
Bench: 1381658