### PR TITLE
Search/mdp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -308,7 +308,7 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 
 		// Mate distance pruning
 		alpha = std::max(alpha, -MATE_SCORE + (int)pos->ply);
-		beta = std::min(beta, MATE_SCORE - (int)pos->ply - 1);
+		beta = std::min(beta, MATE_SCORE - (int)pos->ply);
 		if (alpha >= beta) {
 			return alpha;
 		}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -307,13 +307,11 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 		}
 
 		// Mate distance pruning
-		/*
 		alpha = std::max(alpha, -MATE_SCORE + (int)pos->ply);
 		beta = std::min(beta, MATE_SCORE - (int)pos->ply - 1);
 		if (alpha >= beta) {
 			return alpha;
 		}
-		*/
 	}
 
 	if (depth <= 0) {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,8 +315,8 @@ static inline int negamax_alphabeta(Board* pos, HashTable* table, SearchInfo* in
 
 	// Mate distance pruning
 	// If we have already found a mate, prune nodes where no shorter mate is possible
-	alpha = std::max(alpha, -MATE_SCORE + (int)pos->ply);
-	beta = std::min(beta, MATE_SCORE - (int)pos->ply);
+	alpha = std::max(alpha, -INF_BOUND + (int)pos->ply);
+	beta = std::min(beta, INF_BOUND - (int)pos->ply);
 	if (alpha >= beta) {
 		return alpha;
 	}


### PR DESCRIPTION
```
Elo   | -0.07 +- 2.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.12 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 31238 W: 10831 L: 10837 D: 9570
Penta | [1299, 3192, 6701, 3070, 1357]
``` https://kelseyde.pythonanywhere.com/test/1435/
Bench: 1381658