### PR TITLE
Bugfix/eval queen

### DIFF
--- a/src/eval/evaluate.cpp
+++ b/src/eval/evaluate.cpp
@@ -284,7 +284,8 @@ static inline int evaluate_bishops(const Board& pos, uint8_t pce, int phase) {
 
         // Penalty for bishops blocking centre pawns
         if (file == FILE_D || file == FILE_E) {
-            Bitboard pawn_mask = pos.bitboards[pce] & file_masks[file];
+            uint8_t ally_pawns = (pce == wB) ? wP : bP;
+            Bitboard pawn_mask = pos.bitboards[ally_pawns] & file_masks[file];
             uint8_t pawn_sq = pop_ls1b(pawn_mask);
             int8_t sign = (piece_col[pce] == WHITE) ? -1 : 1;
             if (sq - pawn_sq == sign * 8) {

--- a/src/eval/evaluate.cpp
+++ b/src/eval/evaluate.cpp
@@ -363,8 +363,8 @@ static inline int evaluate_queens(const Board& pos, uint8_t pce, int phase) {
     while (queens) {
         uint8_t sq = pop_ls1b(queens);
         uint8_t file = GET_FILE(sq);
-        uint8_t ally_pawns = (pce == wR) ? wP : bP;
-        uint8_t enemy_pawns = (pce == wR) ? bP : wP;
+        uint8_t ally_pawns = (pce == wQ) ? wP : bP;
+        uint8_t enemy_pawns = (pce == wQ) ? bP : wP;
         score += compute_PSQT(pce, sq, phase);
 
         // Bonus for taking semi-open and open files


### PR DESCRIPTION
Fixed typos in evaluate_bishops() and evaluate_queens().
```
Elo   | -0.94 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 54488 W: 18673 L: 18820 D: 16995
Penta | [2759, 5818, 10215, 5715, 2737]
```
https://openbench.nocturn9x.space/test/5105/ 
Bench: 2150707