### PR TITLE
Search/tm-refactor

### DIFF
--- a/src/UciHandler.cpp
+++ b/src/UciHandler.cpp
@@ -88,7 +88,7 @@ void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, const 
 
     // Time Management
     // Add a buffer for handling Engine <-> GUI communication latency (esp. for OpenBench)
-    constexpr int MIN_NETWORK_BUFFER = 100;  // in ms
+    constexpr int MIN_NETWORK_BUFFER = 75;  // in ms
     if (movetime != -1) {
         // No time management, directly use available time (- buffer)
         info.timeset = true;
@@ -99,16 +99,12 @@ void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, const 
 
         // Get hard time limit
         int buffered_time =
-            std::max((time + inc / 2) / 10 - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER);
+            std::max((time + inc * 3 / 4) / 10 - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER);
         info.hard_stop_time = info.start_time + buffered_time;
-
-        // Get soft time limit
-        // buffered_time = std::max((time + inc/2) / 30 - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER /
-        // 2); info.soft_stop_time = info.start_time + buffered_time;
 
         // Get soft time limit based on current ply (phase)
         buffered_time =
-            std::max(allocate_time(pos, (time + inc / 2) * 95 / 100) - MIN_NETWORK_BUFFER,
+            std::max(allocate_time(pos, (time + inc * 3 / 4) * 95 / 100) - MIN_NETWORK_BUFFER,
                      MIN_NETWORK_BUFFER / 2);
         // Prevent soft limit from exceeding hard limit
         info.soft_stop_time =
@@ -242,16 +238,6 @@ void UciHandler::uci_loop(Board& pos, HashTable& table, SearchInfo& info, UciOpt
             int eval = evaluate_pos(pos);
             std::cout << "Static evaluation: " << eval << "cp\n";
         } else if (line.substr(0, 9) == "test") {
-            std::string test_fen = "2q1k2r/R2n2b1/3P2p1/2PQp2n/1p3p1p/4BP2/1P3NPP/6K1 b k - 1 26";
-            parse_fen(pos, test_fen);
-            for (int i = 0; i < 500'000; ++i) {
-                evaluate_pos(pos);
-                if (i % 100'000 == 99'999) {
-                    std::cout << "Evaluation #" << i << "\n";
-                }
-            }
-            std::cout << "Static evaluation: " << evaluate_pos(pos) << "cp \n";
-        } else if (line.substr(0, 10) == "test2") {
             // TODO: Fix hash discrepancy
             std::string test_fen =
                 "r1b1k1nr/ppqn1pbp/2pp2p1/4pP2/3PP3/3B1N2/PPP3PP/RNBQK2R w KQkq e6 0 1";

--- a/src/UciHandler.cpp
+++ b/src/UciHandler.cpp
@@ -46,7 +46,7 @@ UciHandler::UciHandler() {
 //           go nodes <>
 //           go infinite (although no stop command at the moment, can only be stopped via keyboard
 //           interrupt)
-void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, const std::string& line) {
+void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, UciOptions* options, const std::string& line) {
     // int movestogo = 30;
     int time = -1, movetime = -1;
     int depth = -1, inc = 0, nodes = -1;
@@ -87,27 +87,25 @@ void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, const 
     info.depth = depth;
 
     // Time Management
-    // Add a buffer for handling Engine <-> GUI communication latency (esp. for OpenBench)
-    constexpr int MIN_NETWORK_BUFFER = 100;  // in ms
     if (movetime != -1) {
         // No time management, directly use available time (- buffer)
         info.timeset = true;
-        int buffered_time = std::max(movetime - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER);
+        int buffered_time = std::max(movetime - (int)options->move_overhead, (int)options->move_overhead);
         info.hard_stop_time = info.soft_stop_time = info.start_time + buffered_time;
     } else if (time != -1) {
         info.timeset = true;
 
         // Get hard time limit
         int buffered_time =
-            std::max((time + inc * 3 / 4) / 10 - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER);
+            std::max((time + inc * 3 / 4) / 10 - (int)options->move_overhead, (int)options->move_overhead);
         info.hard_stop_time = info.start_time + buffered_time;
 
         // Get soft time limit based on current ply (phase)
         buffered_time =
-            std::max(allocate_time(pos, time, inc) - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER / 10);
+            std::max(allocate_time(pos, time, inc) - (int)options->move_overhead, (int)options->move_overhead / 10);
         // Prevent soft limit from exceeding hard limit
         info.soft_stop_time =
-            std::min(info.start_time + buffered_time, info.hard_stop_time - MIN_NETWORK_BUFFER);
+            std::min(info.start_time + buffered_time, info.hard_stop_time - (int)options->move_overhead);
 
         // std::cout << "Current time: " << get_time_ms()
         //    << " | Hard limit: " << info.hard_stop_time << " (" << info.hard_stop_time -
@@ -172,11 +170,15 @@ void UciHandler::uci_loop(Board& pos, HashTable& table, SearchInfo& info, UciOpt
     // UCI Options
     std::cout << "option name Hash type spin default 16 min " << MIN_HASH << " max " << MAX_HASH
               << std::endl;
+    std::cout << "option name Threads type spin default 1 min 1 max 1" << std::endl;
+    std::cout << "option name Move Overhead type spin default 75 min 0 max 5000" << std::endl;
+    std::cout << "uciok" << std::endl;
+
     int MB = 16;
     options->hash_size = 16;
+    options->threads = 1;
+    options->move_overhead = 75;
     init_hash_table(table, MB);
-    std::cout << "option name Threads type spin default 1 min 1 max 1" << std::endl;
-    std::cout << "uciok" << std::endl;
 
     parse_fen(pos, START_POS);
 
@@ -209,10 +211,10 @@ void UciHandler::uci_loop(Board& pos, HashTable& table, SearchInfo& info, UciOpt
                 run_perft(pos, depth, true);
             } else {
                 // Normal go command
-                parse_go(pos, table, info, line);
+                parse_go(pos, table, info, options, line);
             }
         } else if (line.substr(0, 3) == "run") {
-            parse_go(pos, table, info, "go infinite");
+            parse_go(pos, table, info, options, "go infinite");
         } else if (line.substr(0, 4) == "quit") {
             info.quit = true;
             break;
@@ -229,7 +231,17 @@ void UciHandler::uci_loop(Board& pos, HashTable& table, SearchInfo& info, UciOpt
                 init_hash_table(table, MB);
                 std::cout << "info string Set Hash to " << MB << " MB" << std::endl;
             } else {
-                std::cout << "Invalid Hash value" << std::endl;
+                std::cout << "info string Invalid Hash value" << std::endl;
+            }
+        } else if (line.substr(0, 35) == "setoption name Move Overhead value ") {
+            std::istringstream iss(line.substr(35));
+            int new_overhead;
+            if (iss >> new_overhead) { 
+                options->move_overhead = CLAMP(new_overhead, 0, 5000);
+                std::cout << "info string Set Move Overhead to " << options->move_overhead << " ms"
+                          << std::endl;
+            } else {
+                std::cout << "info string Invalid Move Overhead value" << std::endl;
             }
         } else if (line.substr(0, 5) == "print") {
             print_board(pos);

--- a/src/UciHandler.cpp
+++ b/src/UciHandler.cpp
@@ -88,7 +88,7 @@ void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, const 
 
     // Time Management
     // Add a buffer for handling Engine <-> GUI communication latency (esp. for OpenBench)
-    constexpr int MIN_NETWORK_BUFFER = 75;  // in ms
+    constexpr int MIN_NETWORK_BUFFER = 100;  // in ms
     if (movetime != -1) {
         // No time management, directly use available time (- buffer)
         info.timeset = true;
@@ -104,8 +104,7 @@ void UciHandler::parse_go(Board& pos, HashTable& table, SearchInfo& info, const 
 
         // Get soft time limit based on current ply (phase)
         buffered_time =
-            std::max(allocate_time(pos, (time + inc * 3 / 4) * 95 / 100) - MIN_NETWORK_BUFFER,
-                     MIN_NETWORK_BUFFER / 2);
+            std::max(allocate_time(pos, time, inc) - MIN_NETWORK_BUFFER, MIN_NETWORK_BUFFER / 10);
         // Prevent soft limit from exceeding hard limit
         info.soft_stop_time =
             std::min(info.start_time + buffered_time, info.hard_stop_time - MIN_NETWORK_BUFFER);

--- a/src/UciHandler.hpp
+++ b/src/UciHandler.hpp
@@ -31,16 +31,16 @@
 
 // UCI options struct
 typedef struct {
-    uint16_t hash_size;  // type spin
-    uint16_t threads;    // type spin
-                         // bool use_book; // type check
+    uint32_t hash_size;     // type spin
+    uint16_t threads;       // type spin
+    uint16_t move_overhead; // type spin
 } UciOptions;
 
 class UciHandler {
    public:
     UciHandler();  // Blank constructor
 
-    void parse_go(Board& pos, HashTable& table, SearchInfo& info, const std::string& line);
+    void parse_go(Board& pos, HashTable& table, SearchInfo& info, UciOptions* options, const std::string& line);
     void parse_position(Board& pos, const std::string& line);
     void uci_loop(Board& pos, HashTable& table, SearchInfo& info, UciOptions* options);
 

--- a/src/chess/bench.hpp
+++ b/src/chess/bench.hpp
@@ -67,7 +67,12 @@ std::string bench_positions[] = {
 constexpr uint8_t BENCH_DEPTH = 8;
 
 static inline void run_bench(Board& pos, HashTable& table, SearchInfo& info, UciHandler uci) {
+    UciOptions options;
+    options.hash_size = 16;
+    options.threads = 1;
+    options.move_overhead = 75;
     init_hash_table(table, 16);
+
     uint64_t total_nodes = 0;
     uint64_t start = get_time_ms();
 
@@ -77,7 +82,7 @@ static inline void run_bench(Board& pos, HashTable& table, SearchInfo& info, Uci
         std::cout << "Position: " << bench_positions[index] << "\n";
         parse_fen(pos, bench_positions[index]);
         std::string command = "go depth " + std::to_string(BENCH_DEPTH);
-        uci.parse_go(pos, table, info, command);
+        uci.parse_go(pos, table, info, &options, command);
         total_nodes += info.nodes;
     }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,7 +28,7 @@ int allocate_time(const Board& pos, int base_time, int inc) {
         // start_val + (end_val - start_val) * (1.0 - (current_time / max_time))
         // Can be more aggressive with increment
         const double START = std::max(40.0 - inc / 5.0, 10.0);
-        const double END = std::max(120.0 - inc / 2.0, 20.0);
+        const double END = std::max(60.0 - inc / 5.0, 20.0);
         double dynamic_divisor = START + (END - START) * (1.0 - (double)std::max(0, time) / TIME_TROUBLE_THRESHOLD);
         return time / (int)dynamic_divisor;
     }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -18,15 +18,17 @@ uint64_t get_time_ms() {
 
 // Allocate time based on the current ply, which is used to determine the phase of the game
 // Returns the time allocated in milliseconds
-int allocate_time(const Board& pos, int time) {
+int allocate_time(const Board& pos, int base_time, int inc) {
+    int time = (base_time + inc * 3 / 4) * 95 / 100;
 
     // TIME TROUBLE CAES: Allocate time dynamically based on time left
-    const int TIME_TROUBLE_THRESHOLD = 15000; // in ms
+    const int TIME_TROUBLE_THRESHOLD = 30000; // in ms
     if (time < TIME_TROUBLE_THRESHOLD) {
         // Linear interpolation formula:
         // start_val + (end_val - start_val) * (1.0 - (current_time / max_time))
-        const double START = 10.0;
-        const double END = 20.0;
+        // Can be more aggressive with increment
+        const double START = std::max(40.0 - inc / 5.0, 10.0);
+        const double END = std::max(120.0 - inc / 2.0, 20.0);
         double dynamic_divisor = START + (END - START) * (1.0 - (double)std::max(0, time) / TIME_TROUBLE_THRESHOLD);
         return time / (int)dynamic_divisor;
     }
@@ -47,5 +49,5 @@ int allocate_time(const Board& pos, int time) {
     }
 
     // ENDGAME PHASE: Flat divisor until time trouble
-    return time / 35;
+    return time / 40;
 }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <iostream>
 
+
+
 // Get time in milliseconds
 uint64_t get_time_ms() {
     auto now = std::chrono::steady_clock::now();  // Get the current time point
@@ -17,33 +19,33 @@ uint64_t get_time_ms() {
 // Allocate time based on the current ply, which is used to determine the phase of the game
 // Returns the time allocated in milliseconds
 int allocate_time(const Board& pos, int time) {
-    // Time trouble case
-    if (time < 15000) {  // 15s
-        return time / 35;
+
+    // TIME TROUBLE CAES: Allocate time dynamically based on time left
+    const int TIME_TROUBLE_THRESHOLD = 15000; // in ms
+    if (time < TIME_TROUBLE_THRESHOLD) {
+        // Linear interpolation formula:
+        // start_val + (end_val - start_val) * (1.0 - (current_time / max_time))
+        const double START = 10.0;
+        const double END = 20.0;
+        double dynamic_divisor = START + (END - START) * (1.0 - (double)std::max(0, time) / TIME_TROUBLE_THRESHOLD);
+        return time / (int)dynamic_divisor;
     }
 
-    // Based on https://www.chessprogramming.org/File:GrandmasterThinkingTime.jpg
+
+    // OPENING / MIDDLEGAME PHASE: Allocate time dynamically based on game phase
+    // (Based on https://www.chessprogramming.org/File:GrandmasterThinkingTime.jpg)
     // We obtain 11.5%, 72.4%, 16.1% for opening, middlegame, endgame respectively based on our
-    // thresholds Of course, the exact numbers are quite arbitrary, but the main idea lies in the
+    // thresholds. Of course, the exact numbers are quite arbitrary, but the main idea lies in the
     // relative proportions
-    constexpr uint8_t OPENING_PLY = 30;  // 15 moves
-    constexpr uint8_t MIDGAME_PLY = 80;  // 40 moves
-    int time_allocated = 0, phase_moves = 0;
+    const Phase stages[] = { {30, 12}, {80, 82} }; // Opening, Middlegame
 
-    if (pos.his_ply <= OPENING_PLY) {
-        // Opening phase (12% / 72% / 16%)
-        phase_moves = (OPENING_PLY + 10 - pos.his_ply) / 2;  // Add an additional 10 ply as buffer
-        time_allocated = time * 12 / (100 * phase_moves);
-    } else if (pos.his_ply <= MIDGAME_PLY) {
-        // Middlegame phase (72% / 16% -> 82% / 12%)
-        phase_moves = (MIDGAME_PLY + 10 - pos.his_ply) / 2;
-        time_allocated = time * 82 / (100 * phase_moves);
-    } else {
-        // Endgame phase (divide evenly rather conservatively)
-        time_allocated = time / 35;
+    for (const auto& stage : stages) {
+        if (pos.his_ply <= stage.limit) {
+            int moves = (stage.limit + 10 - pos.his_ply) / 2;
+            return (time * stage.weight) / (100 * std::max(1, moves));
+        }
     }
 
-    // std::cout << "Original time: " << time << ", Ply: " << (int)pos.his_ply << " | Allocated
-    // time: " << time_allocated << "ms\n";
-    return time_allocated;
+    // ENDGAME PHASE: Flat divisor until time trouble
+    return time / 35;
 }

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -11,6 +11,6 @@ struct Phase {
 };
 
 uint64_t get_time_ms();
-int allocate_time(const Board& pos, int time);
+int allocate_time(const Board& pos, int base_time, int inc);
 
 #endif  // TIMEMAN_HPP

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -5,6 +5,11 @@
 
 #include "Board.hpp"
 
+struct Phase { 
+    int limit; 
+    int weight; 
+};
+
 uint64_t get_time_ms();
 int allocate_time(const Board& pos, int time);
 


### PR DESCRIPTION
Not as much of a refactor as I intended. Added a UCI option for Move Overhead to reduce timeouts on Lichess.
Allows better time usage in STC or similar time controls, by having less buffer and more aggressive time management.
1000-game match against Stash v17 (2295) - W510 D109 L381. 45 +/- 20.
Was closer to -100 ~ -200 in similar settings before.

This change should be pretty much neutral in longer TCs as it applies to low time scenarios only.

Bench: 2064228
