### PR TITLE
Add !in_check condition before qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -269,11 +269,18 @@ static inline int negamax_alphabeta(Board& pos, HashTable& table, SearchInfo& in
         info.seldepth = pos.ply;
     }
 
+    uint8_t US = pos.side;
+    uint8_t THEM = US ^ 1;
+    bool in_check = is_square_attacked(pos, pos.king_sq[US], THEM);
+
     // Drop to qsearch at depth 0 or lower
-    if (depth <= 0) {
+    if (depth <= 0 && !in_check) {
         return quiescence(pos, table, info, alpha, beta, line);
     }
 
+    depth = std::max(depth, 0); // Ensure depth is non-negative
+
+    // Check draw
     if (!is_root) {
         // Check draw
         int flag = check_draw(pos, false);
@@ -299,11 +306,7 @@ static inline int negamax_alphabeta(Board& pos, HashTable& table, SearchInfo& in
     PVLine candidate_PV;
     init_PVLine(&candidate_PV);
 
-    uint8_t US = pos.side;
-    uint8_t THEM = US ^ 1;
-
     // Check extension to avoid horizon effect
-    bool in_check = is_square_attacked(pos, pos.king_sq[US], THEM);
     if (in_check) {
         depth++;
     }


### PR DESCRIPTION
Add !in_check condition in main search, preventing qsearch in a position with checks.
Credit to @Haxk20 for pointing it out (apologies for wrong tag in commit desc)
```
Elo   | 2.32 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.57 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29770 W: 10505 L: 10306 D: 8959
Penta | [1474, 3099, 5604, 3170, 1538]
```
https://openbench.nocturn9x.space/test/6780/
Passes nonreg according to [this calculator](https://elocalculator.netlify.app/).
```
Points: 14949 / 29696 (50.34%)
Elo: 2.36 (-3.30 / +3.30) [-0.94 to 5.67]
nElo: 2.83 (-3.95 / +3.95) [-1.13 to 6.78]
BayesElo: 2.60 (-3.63 / +3.63) [-1.03 to 6.23]
LLR: 6.5495
````
Bench: 1982693