### PR TITLE
Add !is_root check to check extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ I would also like to thank:
 ## Playing Strength
 |   Version   | CCRL 2+1 est. | [UBC](https://e4e6.com/) |
 |:-----------:|:-------------:|:-----:|
-| v0.29 (dev) |     ~2264     |   -   |
+| v0.29 (dev) |     ~2330     |   -   |
 |    v0.25    |     ~2136     | 2157  |
 - CCRL rating estimates are obtained from tests against Stash v17 (rated 2295 CCRL 2+1).
 - Note that the estimated ratings in the C repo are not accurate, as the engine used in gauntlets are bugged.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -307,7 +307,7 @@ static inline int negamax_alphabeta(Board& pos, HashTable& table, SearchInfo& in
     init_PVLine(&candidate_PV);
 
     // Check extension to avoid horizon effect
-    if (in_check) {
+    if (in_check && !is_root) {
         depth++;
     }
 


### PR DESCRIPTION
As the title implies. The issue was it would essentially start with depth 2 search in positions with check. Evidently it doesn't affect much on a grand scheme of things.
```
Elo   | 0.10 +- 2.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 27060 W: 9882 L: 9874 D: 7304
Penta | [1120, 2349, 6551, 2423, 1087]
```
https://openbench.nocturn9x.space/test/6794/

Bench: 1972661