### PR TITLE
Move quiethist inside beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -503,6 +503,9 @@ static inline int negamax_alphabeta(Board& pos, HashTable& table, SearchInfo& in
                     if (!is_capture) {
                         pos.killer_moves[1][pos.ply] = pos.killer_moves[0][pos.ply];
                         pos.killer_moves[0][pos.ply] = curr_move;
+
+                        pos.history_moves[get_move_piece(best_move)][get_move_target(best_move)] +=
+                        depth * depth;
                     }
 
                     break;  // Fail-high
@@ -515,12 +518,6 @@ static inline int negamax_alphabeta(Board& pos, HashTable& table, SearchInfo& in
                 line->length = 1 + candidate_PV.length;
                 line->moves[0] = curr_move;
                 std::memcpy(line->moves + 1, candidate_PV.moves, sizeof(int) * candidate_PV.length);
-
-                // Store the move that beats alpha if it's quiet
-                if (!is_capture) {
-                    pos.history_moves[get_move_piece(best_move)][get_move_target(best_move)] +=
-                        depth * depth;
-                }
             }
         }
     }


### PR DESCRIPTION
This part of the code was unchanged from VICE. There was a problem, you're supposed to update quiethist when the score beats beta, not just beats alpha.
```
Elo   | 42.72 +- 14.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1414 W: 597 L: 424 D: 393
Penta | [48, 115, 266, 172, 106]
```
https://openbench.nocturn9x.space/test/6796/ 
A massive gain for a bugfix
Bench: 2104343