### PR TITLE
Fix depth in PVS searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -471,13 +471,13 @@ static inline int negamax_alphabeta(Board& pos, HashTable& table, SearchInfo& in
         // move
         else if (!PV_node || legal > 1) {
             // Perform zero-window search (ZWS) on non-PV nodes
-            score = -negamax_alphabeta(pos, table, info, -alpha - 1, -alpha, reduced_depth,
+            score = -negamax_alphabeta(pos, table, info, -alpha - 1, -alpha, depth - 1,
                                        &candidate_PV, true, false);
         }
         // If we're in a PV node and searching the first move, or the score from reduced search beat
         // alpha, then we search with full depth and alpha-beta window.
         if (PV_node && (legal == 1 || score > alpha)) {
-            score = -negamax_alphabeta(pos, table, info, -beta, -alpha, reduced_depth,
+            score = -negamax_alphabeta(pos, table, info, -beta, -alpha, depth - 1,
                                        &candidate_PV, true, true);
         }
 


### PR DESCRIPTION
A subtle bug. On LMR researches, `reduced_depth` are not depth-1, but still the depth reduced from LMR. This caused the researches to start at wrong depths. Now, they simply just use depth-1 for clarity instead of the variable.
```
Elo   | 54.32 +- 16.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1122 W: 472 L: 298 D: 352
Penta | [32, 93, 195, 151, 90]
```
https://openbench.nocturn9x.space/test/6797/ Another banger
Bench: 2384151