### PR TITLE
Fix make move en passant bug

### DIFF
--- a/Dragonrose.json
+++ b/Dragonrose.json
@@ -1,0 +1,69 @@
+{
+    "private" : false,
+    "nps"     : 1000000,
+    "source"  : "https://github.com/TampliteSK/dragonrose_cpp",
+
+    "build" : {
+        "path"      : "",
+        "compilers" : ["g++", "clang++"],
+        "cpuflags"  : [],
+        "systems"   : ["Windows", "Linux"]
+    },
+
+    "test_presets" : {
+
+        "default" : {
+            "base_branch"     : "master",
+            "book_name"       : "UHO_Lichess_4852_v1.epd",
+            "test_bounds"     : "[0.00, 5.00]",
+            "test_confidence" : "[0.05, 0.05]",
+            "win_adj"         : "movecount=3 score=400",
+            "draw_adj"        : "movenumber=40 movecount=8 score=10"
+        },
+
+        "STC" : {
+            "both_options"      : "Threads=1 Hash=16",
+            "both_time_control" : "8.0+0.08",
+            "workload_size"     : 32
+        },
+
+        "LTC" : {
+            "both_options"      : "Threads=1 Hash=32",
+            "both_time_control" : "40.0+0.4",
+            "workload_size"     : 8
+        },
+
+        "STC regression" : {
+            "both_options"      : "Threads=1 Hash=16",
+            "both_time_control" : "8.0+0.08",
+            "workload_size"     : 32,
+            "test_bounds"       : "[-5.00, 0.00]"
+        },
+
+        "LTC regression" : {
+            "both_options"      : "Threads=1 Hash=32",
+            "both_time_control" : "40.0+0.4",
+            "workload_size"     : 8,
+            "test_bounds"       : "[-5.00, 0.00]"
+        }
+    },
+
+    "tune_presets" : {
+
+        "default" : {
+            "book_name" : "UHO_Lichess_4852_v1.epd",
+            "win_adj"   : "movecount=3 score=400",
+            "draw_adj"  : "movenumber=40 movecount=8 score=10"
+        },
+
+        "STC" : {
+            "dev_options"      : "Threads=1 Hash=16",
+            "dev_time_control" : "8.0+0.08"
+        },
+
+        "LTC" : {
+            "dev_options"      : "Threads=1 Hash=32",
+            "dev_time_control" : "40.0+0.4"
+        }
+    }
+}

--- a/src/UciHandler.cpp
+++ b/src/UciHandler.cpp
@@ -259,7 +259,7 @@ void UciHandler::uci_loop(Board& pos, HashTable& table, SearchInfo& info, UciOpt
             // list.length = 1;
             // print_move_list(list, true);
             make_move(pos, move);
-            print_board(pos);
+            // print_board(pos);
 
             take_move(pos);
             print_board(pos);

--- a/src/chess/makemove.cpp
+++ b/src/chess/makemove.cpp
@@ -199,11 +199,13 @@ bool make_move(Board &pos, int move) {
     HASH_CA(pos);
     pos.fifty_move++;
 
-    // Handle captures
+    // Handle captures (en passant capture was already removed at the top)
     int captured = get_move_captured(move);
-    if (captured) {
+    if (captured && !get_move_enpassant(move)) {
         clear_piece(pos, to);
-        pos.fifty_move = 0;  // A capture is played - reset 50-move counter
+    }
+    if (captured) {
+        pos.fifty_move = 0;  // capture (incl. EP) resets the 50-move counter
     }
 
     pos.ply++;


### PR DESCRIPTION
Fixed a bug where positions with en passant would have wrong hash when making move and taking back 
```
Elo   | 49.11 +- 16.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 1118 W: 464 L: 307 D: 347
Penta | [32, 92, 207, 143, 85]
```
https://openbench.nocturn9x.space/test/7264/
Bench: 2057155